### PR TITLE
Prep for proper release 0.1.2 to be completed

### DIFF
--- a/Cortex-Forth/c0ffee
+++ b/Cortex-Forth/c0ffee
@@ -1,2 +1,2 @@
-# Mon Aug  5 19:44:38 UTC 2019
+# Mon Aug  5 20:49:19 UTC 2019
 $ git reset --hard 1fa91ee8cf41c


### PR DESCRIPTION
	modified:   c0ffee
On branch reversed-aa

This should be the first good release.  0.1.0 and 0.1.1 are defunct (do not use them).